### PR TITLE
Update String+Extensions.swift

### DIFF
--- a/Source/Extensions/String+Extensions.swift
+++ b/Source/Extensions/String+Extensions.swift
@@ -13,7 +13,7 @@ extension String {
     subscript (r: Range<Int>) -> String {
         let start = index(startIndex, offsetBy: r.lowerBound)
         let end = index(startIndex, offsetBy: r.upperBound)
-        return String(self[Range(start ..< end)])
+        return String(self[start ..< end])
     }
     
     var containsAlphabets: Bool {


### PR DESCRIPTION
TMXAlertsPickers won't build in Xcode 10 due String.swift extension method subscript (r:Range) -> String.
Error lies in
`return String(self[Range(start..<end)])`
Range no longer supports start to end values in call.

Updated to 
`return String(self[start ..< end])`